### PR TITLE
Add VM folder resource

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -36,6 +36,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"vmware_virtual_machine": resourceVirtualMachine(),
+			"vmware_vm_folder":       resourceVmFolder(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -63,7 +63,7 @@ func resourceVmFolderRead(d *schema.ResourceData, meta interface{}) error {
 	mor := types.ManagedObjectReference{Type: "Folder", Value: d.Id()}
 	obj, err := finder.ObjectReference(ctx, mor)
 	if err != nil {
-		d.Set("name", "")
+		d.SetId("")
 		return nil
 	}
 

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25"
+	"golang.org/x/net/context"
+	"fmt"
+)
+
+func resourceVmFolder() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVmFolderCreate,
+		Read:   resourceVmFolderRead,
+		Delete: resourceVmFolderDelete,
+
+		Schema: map[string]*schema.Schema{
+			"parent": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			// create parent folders
+		},
+	}
+}
+
+func resourceVmFolderCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*vim25.Client)
+	finder := find.NewFinder(client, false)
+	ctx := context.TODO()
+
+	parent_name := d.Get("parent").(string)
+	name := d.Get("name").(string)
+
+	parent_folder, err := finder.Folder(ctx, parent_name)
+	if err != nil {
+		return fmt.Errorf("Cannot find parent folder: %s", err)
+	}
+
+	folder, err := parent_folder.CreateFolder(ctx, name)
+	if err != nil {
+		return fmt.Errorf("Cannot create folder: %s", err)
+	}
+
+	d.SetId(folder.InventoryPath)
+
+	return nil
+}
+
+func resourceVmFolderRead(d *schema.ResourceData, meta interface{}) error {
+
+	return nil
+}
+
+func resourceVmFolderDelete(d *schema.ResourceData, meta interface{}) error {
+
+	// check VMs inside
+
+	return nil
+}

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -67,6 +67,10 @@ func resourceVmFolderDelete(d *schema.ResourceData, meta interface{}) error {
 	mor := types.ManagedObjectReference{Type: "Folder", Value: d.Id()}
 	folder := object.NewFolder(client, mor)
 
+	if children, _ := folder.Children(ctx); len(children) > 0 {
+		return fmt.Errorf("Folder is not empty")
+	}
+
 	task, err := folder.Destroy(ctx)
 	if err != nil {
 		return fmt.Errorf("Error deleting folder: %s", err)

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -28,6 +28,10 @@ func resourceVmFolder() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					value := v.(string)
+					return strings.Trim(value, "/")
+				},
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -49,7 +49,7 @@ func resourceVmFolderCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Cannot create folder: %s", err)
 	}
 
-	d.SetId(folder.InventoryPath)
+	d.SetId(folder.Reference().Value)
 
 	return nil
 }

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -103,6 +103,7 @@ func resourceVmFolderUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	folder := obj.(*object.Folder)
 
+	d.Partial(true)
 	if d.HasChange("name") {
 		name := d.Get("name").(string)
 		task, err := folder.Rename(ctx, name)
@@ -113,6 +114,7 @@ func resourceVmFolderUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Cannot rename folder: %s", err)
 		}
+		d.SetPartial("name")
 	}
 
 	if d.HasChange("parent") {
@@ -133,8 +135,10 @@ func resourceVmFolderUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Cannot move folder: %s", err)
 		}
+		d.SetPartial("parent")
 	}
 
+	d.Partial(false)
 	return nil
 }
 

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -30,7 +30,8 @@ func resourceVmFolder() *schema.Resource {
 				Required: true,
 				StateFunc: func(v interface{}) string {
 					value := v.(string)
-					return strings.Trim(value, "/")
+					path :=  strings.Trim(value, "/")
+					return strings.Join([]string{"/", path}, "")
 				},
 			},
 			"name": {

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -57,18 +57,23 @@ func resourceVmFolderCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceVmFolderRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*vim25.Client)
+	finder := find.NewFinder(client, false)
 	ctx := context.TODO()
 
 	mor := types.ManagedObjectReference{Type: "Folder", Value: d.Id()}
-	folder := object.NewFolder(client, mor)
-
-	name, err := folder.ObjectName(ctx)
-	if err == nil {
-		d.Set("name", name)
-	} else {
+	obj, err := finder.ObjectReference(ctx, mor)
+	if err != nil {
 		d.Set("name", "")
+		return nil
 	}
 
+	folder := obj.(*object.Folder)
+	name, err := folder.ObjectName(ctx)
+	if err != nil {
+		return fmt.Errorf("Cannot read folder: %s", err)
+	}
+
+	d.Set("name", name)
 	return nil
 }
 

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -19,17 +19,17 @@ func resourceVmFolder() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			// TODO: move to provider parameters
-			"datacenter": &schema.Schema{
+			"datacenter": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"parent": &schema.Schema{
+			"parent": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/object"
+	"strings"
 )
 
 func resourceVmFolder() *schema.Resource {
@@ -17,6 +18,12 @@ func resourceVmFolder() *schema.Resource {
 		Delete: resourceVmFolderDelete,
 
 		Schema: map[string]*schema.Schema{
+			// TODO: move to provider parameters
+			"datacenter": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"parent": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -38,10 +45,13 @@ func resourceVmFolderCreate(d *schema.ResourceData, meta interface{}) error {
 	finder := find.NewFinder(client, false)
 	ctx := context.TODO()
 
+	datacenter := d.Get("datacenter").(string)
 	parent_name := d.Get("parent").(string)
 	name := d.Get("name").(string)
 
-	parent_folder, err := finder.Folder(ctx, parent_name)
+	path := strings.Join([]string{datacenter, "vm", parent_name}, "/")
+
+	parent_folder, err := finder.Folder(ctx, path)
 	if err != nil {
 		return fmt.Errorf("Cannot find parent folder: %s", err)
 	}

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -56,6 +56,18 @@ func resourceVmFolderCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVmFolderRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*vim25.Client)
+	ctx := context.TODO()
+
+	mor := types.ManagedObjectReference{Type: "Folder", Value: d.Id()}
+	folder := object.NewFolder(client, mor)
+
+	name, err := folder.ObjectName(ctx)
+	if err == nil {
+		d.Set("name", name)
+	} else {
+		d.Set("name", "")
+	}
 
 	return nil
 }

--- a/resource_vm_folder.go
+++ b/resource_vm_folder.go
@@ -39,7 +39,7 @@ func resourceVmFolder() *schema.Resource {
 				ForceNew: true,
 			},
 
-			// create parent folders
+			// TODO: create parent folders?
 		},
 	}
 }

--- a/test/13-folder/folder.tf
+++ b/test/13-folder/folder.tf
@@ -7,6 +7,6 @@ provider "vmware" {
 
 resource "vmware_vm_folder" "test" {
   datacenter = "DC1"
-  parent =  "folder1"
+  parent =  "/folder1"
   name =  "test"
 }

--- a/test/13-folder/folder.tf
+++ b/test/13-folder/folder.tf
@@ -6,6 +6,6 @@ provider "vmware" {
 }
 
 resource "vmware_vm_folder" "test" {
-  parent =  "/SPB/vm/parent"
+  parent =  "/DC1/vm/folder1"
   name =  "test"
 }

--- a/test/13-folder/folder.tf
+++ b/test/13-folder/folder.tf
@@ -1,0 +1,11 @@
+provider "vmware" {
+  vcenter_server = "vcenter.vsphere5.test"
+  user = "root"
+  password = "jetbrains"
+  insecure_connection = true
+}
+
+resource "vmware_vm_folder" "test" {
+  parent =  "/SPB/vm/parent"
+  name =  "test"
+}

--- a/test/13-folder/folder.tf
+++ b/test/13-folder/folder.tf
@@ -7,6 +7,6 @@ provider "vmware" {
 
 resource "vmware_vm_folder" "test" {
   datacenter = "DC1"
-  parent =  "/folder1/q/"
+  parent =  "folder1"
   name =  "test"
 }

--- a/test/13-folder/folder.tf
+++ b/test/13-folder/folder.tf
@@ -6,6 +6,7 @@ provider "vmware" {
 }
 
 resource "vmware_vm_folder" "test" {
-  parent =  "/DC1/vm/folder1"
+  datacenter = "DC1"
+  parent =  "/folder1/q/"
   name =  "test"
 }


### PR DESCRIPTION
```
resource "vmware_vm_folder" "test" {
  datacenter = "DC1"
  parent =  "/folder1"
  name =  "test"
}
```

- `datacenter` will be moved to provider level
- parent path and relative name are two separate parameters
- parrent folder must exist, missed subtree is not created automatically
- supports folder renaming
- supports folder moving into different parrent